### PR TITLE
Allowing aborting chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,12 +72,15 @@ function chainit(Constructor) {
 
           args.push(function() {
             var callbackArgs = arguments;
+            var customCallbackResult;
 
             if (customCallback) {
-              customCallback.apply(ctx, callbackArgs);
+              customCallbackResult = customCallback.apply(ctx, callbackArgs);
             }
 
-            callback();
+            if(customCallbackResult !== false) {
+              callback();
+            }
           });
 
           fn.apply(ctx, args);
@@ -87,7 +90,7 @@ function chainit(Constructor) {
       pushTo(currentDepth, task);
 
       return this;
-    }
+    };
   }
 
   Chain.prototype = Object.create(Constructor.prototype);

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ function chainit(Constructor) {
       pushTo(currentDepth, task);
 
       return this;
-    }
+    };
   }
 
   Chain.prototype = Object.create(Constructor.prototype);

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ Features:
 * supports setTimeout(cb)
 * supports methods redifinition
 * supports adding new methods
+* supports aborting the chain -- to abort, custom callback can return `false`
 * fully tested! local: `npm install -g mocha && mocha`, saucelabs: `npm test`
 
 ## tests

--- a/test/chain.js
+++ b/test/chain.js
@@ -365,4 +365,23 @@ describe('chaining an Api', function() {
       })
   });
 
+  describe('supports aborting', function() {
+    it('supports aborting', function(done) {
+      o
+        .concat('Ceci')
+        .concat(' n\'est pas une')
+        .concat(' pipe', function() {
+          assert.equal(o.s, 'Ceci n\'est pas une pipe');
+          setTimeout(done, 1000); // picking a time long enough for the rest of the chain to run.
+          return false;
+        })
+        .concat('t', function() {
+          assert(false, 'This method is not expected to have been invoked.');
+        })
+        .concat('te', function() {
+          assert(false, 'This method is not expected to have been invoked.');
+        });
+    });
+  });
+
 });

--- a/test/chain.js
+++ b/test/chain.js
@@ -365,23 +365,21 @@ describe('chaining an Api', function() {
       })
   });
 
-  describe('supports aborting', function() {
-    it('supports aborting', function(done) {
-      o
-        .concat('Ceci')
-        .concat(' n\'est pas une')
-        .concat(' pipe', function() {
-          assert.equal(o.s, 'Ceci n\'est pas une pipe');
-          setTimeout(done, 1000); // picking a time long enough for the rest of the chain to run.
-          return false;
-        })
-        .concat('t', function() {
-          assert(false, 'This method is not expected to have been invoked.');
-        })
-        .concat('te', function() {
-          assert(false, 'This method is not expected to have been invoked.');
-        });
-    });
+  it('supports aborting', function(done) {
+    o
+      .concat('Ceci')
+      .concat(' n\'est pas une')
+      .concat(' pipe', function() {
+        assert.equal(o.s, 'Ceci n\'est pas une pipe');
+        setTimeout(done, 1000); // picking a time long enough for the rest of the chain to run, if it were allowed to run.
+        return false;
+      })
+      .concat('t', function() {
+        assert(false, 'This method is not expected to have been invoked.');
+      })
+      .concat('te', function() {
+        assert(false, 'This method is not expected to have been invoked.');
+      });
   });
 
 });


### PR DESCRIPTION
The aim of this change is to allow aborting chain.

The change is to read the output of the custom callback and if it's a certain value, e.g. `false`, the rest of the chain is abandoned.
