### PR TITLE
skip functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,20 +155,20 @@ function chainit(Constructor) {
 
   Chain.prototype.__start = function() {
 
-    if(!queues.length && !queues[currentDepth]) {
+    if(!queues.length || !queues[currentDepth-1]) {
       return false;
     }
 
-    queues[currentDepth].start();
+    queues[currentDepth-1].start();
   }
 
   Chain.prototype.__stop = function() {
 
-    if(!queues.length && !queues[currentDepth]) {
+    if(!queues.length || !queues[currentDepth-1]) {
       return false;
     }
 
-    queues[currentDepth].stop();
+    queues[currentDepth-1].stop();
   }
 
   return Chain;
@@ -204,7 +204,7 @@ chainit.start = function start(to) {
  * stop chain
  * @param {Object}   to     Context
  */
-chainit.stop = function start(to) {
+chainit.stop = function stop(to) {
   if (to.prototype && to.prototype.__stop) {
     to.prototype.__stop();
   } else {

--- a/index.js
+++ b/index.js
@@ -14,11 +14,15 @@ function chainit(Constructor) {
   var flushTimeout;
   var flushedTasks = [];
 
+  /**
+   * push chained function into queue
+   */
   function pushTo(depth, task) {
     var queue = queues[depth] || (queues[depth] = getNewQueue(depth));
 
     if (depth > 0) {
-      return queue.push(task);
+      queue.push(task);
+      return queue.start();
     }
 
     // hack to handle cases where first chained calls
@@ -28,6 +32,7 @@ function chainit(Constructor) {
     process.nextTick(function() {
       flushedTasks.unshift(function() {
         queue.push(task);
+        queue.start();
       });
 
       flushTimeout = setTimeout(flush, 4);
@@ -41,13 +46,17 @@ function chainit(Constructor) {
     }
   }
 
+  /**
+   * initialize new queue as subqueue to API command
+   * @param  {Integer} newDepth  queue depth
+   */
   function getNewQueue(newDepth) {
     var queue = new Queue({
       timeout: 0,
       concurrency: 1
     });
 
-    queue.on('drain', function() {
+    queue.on('end', function() {
       if (newDepth > 0) {
         wakeupChain(newDepth);
       }
@@ -61,7 +70,7 @@ function chainit(Constructor) {
       if (!queues[depth + 1] ||
         !queues.slice(depth).some(hasPending)) {
         queues[depth - 1].concurrency = 1;
-        queues[depth - 1].process();
+        queues[depth - 1].start();
       }
 
       if (depth > 1) {
@@ -76,13 +85,17 @@ function chainit(Constructor) {
     return queue;
   }
 
-  // static methods, not chained
+  /**
+   * register static methods, not chained
+   */
   Object.keys(Constructor)
     .forEach(function(name) {
       Chain[name] = new Function(Constructor[name]);
     });
 
-  // prototype methods, chained
+  /**
+   * register prototype methods, chained
+   */
   Object
     .keys(Constructor.prototype)
     .forEach(function(fnName) {
@@ -102,6 +115,7 @@ function chainit(Constructor) {
 
       var ldepth = currentDepth;
 
+      // if parent queue is running, stop it and run new subquene
       if (currentDepth > 0 && queues[currentDepth - 1].concurrency > 0) {
         queues[currentDepth - 1].concurrency = 0;
       }
@@ -113,10 +127,12 @@ function chainit(Constructor) {
         args.push(function() {
           var cbArgs = arguments;
 
+          // if API provides custom async callback, execute it
           if (customCb) {
             customCb.apply(ctx, cbArgs);
           }
 
+          // call required Queue callback
           cb();
         });
 
@@ -124,8 +140,11 @@ function chainit(Constructor) {
       });
       }
 
+      // put async function into queue
       pushTo(currentDepth, task);
 
+      // return this to make API chainable
+      // like api.command1().command2()
       return this;
     }
   }
@@ -134,14 +153,62 @@ function chainit(Constructor) {
     this[fnName] = makeChain(fnName, fn);
   }
 
+  Chain.prototype.__start = function() {
+
+    if(!queues.length && !queues[currentDepth]) {
+      return false;
+    }
+
+    queues[currentDepth].start();
+  }
+
+  Chain.prototype.__stop = function() {
+
+    if(!queues.length && !queues[currentDepth]) {
+      return false;
+    }
+
+    queues[currentDepth].stop();
+  }
+
   return Chain;
 }
 
+/**
+ * add custom function into chain
+ * @param {Object}   to     Context
+ * @param {String}   fnName function name
+ * @param {Function} fn     function
+ */
 chainit.add = function add(to, fnName, fn) {
   if (to.prototype && to.prototype.__addToChain) {
     to.prototype.__addToChain(fnName, fn);
   } else {
     to.__addToChain(fnName, fn);
+  }
+}
+
+/**
+ * start chain
+ * @param {Object}   to     Context
+ */
+chainit.start = function start(to) {
+  if (to.prototype && to.prototype.__start) {
+    to.prototype.__start();
+  } else {
+    to.__start();
+  }
+}
+
+/**
+ * stop chain
+ * @param {Object}   to     Context
+ */
+chainit.stop = function start(to) {
+  if (to.prototype && to.prototype.__stop) {
+    to.prototype.__stop();
+  } else {
+    to.__stop();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "zuul": "~1.0.2"
   },
   "dependencies": {
-    "queue": "~1.0.2"
+    "queue": "~2.2.0"
   },
   "keywords": [
     "chain",

--- a/test/chain.js
+++ b/test/chain.js
@@ -365,4 +365,27 @@ describe('chaining an Api', function() {
       })
   });
 
+  it('supports starting and stopping a queue', function(done) {
+    var hasStopped = false;
+
+    setTimeout(function() {
+      assert.equal(hasStopped,true);
+      chainit.start(o);
+      hasStopped = false;
+    },300)
+
+    o
+      .concat('1')
+      .concat('2')
+      .call(function() {
+        chainit.stop(o);
+        hasStopped = true;
+      })
+      .concat('3',function() {
+        assert.equal(this.s,'123');
+        assert.equal(hasStopped, false);
+        done();
+      })
+  });
+
 });


### PR DESCRIPTION
Hi

I need a functionality for WebdriverJS that makes it possible to skip a bunch of tasks. As described in camme/webdriverjs#137 it would be awesome to do something like this:

``` js
client
  .command() // produces an error
  .command() // will be skipped because of previous error
  .onError(function() {...}) // until here (executed if one of the previous two callbacks were on error)
  .command() // will be executed again
  .command()
```

Take a look into my changes, I hope you like the way I tried to implement it. Basically you just have to determine a function that stops the queue from skipping. I called this function `addNonSkippableFunction` - it is like adding a new function to the API with an additional flag that tells ChainIt that this function should not be skipped. Here is a simple example (I added this one in the Readme.md):

``` js
var obj = new MyChainApi();

// define function that stops skip process
chainit.addNonSkippableFunction(obj,'stopSkiping');

obj
  .method1()
  .call(function() {
    // start skipping
    chainit.skip(obj);
  })
  .method1() // will be skipped
  .method2() // will be skipped
  .stopSkiping(); // stops skipping
  .method1() // will be executed again
```

What do you think?

Cheers
