### PR TITLE
Specify the version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/kapouer/chainit.git"
+  },
+  "engines" : {
+    "node" : ">=0.10.0"
   }
 }


### PR DESCRIPTION
Hello.
I specify the minimum version of node in `package.json` for `chainit-3.0` branch.
